### PR TITLE
wire up GITHUB_TOKEN for private Go module access

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -156,6 +156,7 @@ jobs:
         run: |
           make publish BRANCH_NAME=${GITHUB_REF##*/}
         env:
+          GITHUB_TOKEN: ${{ secrets.UPBOUND_BOT_GITHUB_TOKEN }}
           GO_BUILD_TAG: default
           XPKG_ACCESS_ID: ${{ secrets.XPKG_ACCESS_ID }}
           XPKG_TOKEN: ${{ secrets.XPKG_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,8 @@ GO_SUBDIRS = cmd
 GO_LINT_DIFF_TARGET ?= HEAD~
 GO_LINT_ARGS ?= --fix --new --new-from-rev=$(GO_LINT_DIFF_TARGET)
 GO_BUILD_TAG ?= default
+# For accessing private Go modules
+GITHUB_TOKEN ?= __unset__
 -include build/makelib/golang.mk
 
 # ====================================================================================
@@ -118,7 +120,7 @@ ko.publish: $(KO)
 	@$(INFO) building Go artifacts using ko
 	@for registry in $(REGISTRY_ORGS); do \
 		$(INFO) "Publishing to $$registry"; \
-			VERSION=$(VERSION) GO_BUILD_TAG=$(GO_BUILD_TAG) ./hack/helpers/kobuild.sh $$registry controlplane-mcp-server ./cmd/controlplane-mcp-server; \
+			VERSION=$(VERSION) GO_BUILD_TAG=$(GO_BUILD_TAG) GITHUB_TOKEN=$(GITHUB_TOKEN) ./hack/helpers/kobuild.sh $$registry controlplane-mcp-server ./cmd/controlplane-mcp-server; \
 		$(OK) "Published to $$registry"; \
 	done
 	@$(OK) built Go artifacts using ko

--- a/hack/helpers/kobuild.sh
+++ b/hack/helpers/kobuild.sh
@@ -21,6 +21,11 @@ if [[ -n "$_bare" ]]; then
 fi
 echo $KO_DOCKER_REPO
 
+# Configure git for private module access
+git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
+go env -w GOPRIVATE=github.com/upbound/*
+go mod tidy
+
 # Build the target OCI artifact for the given $_go_import_path.
 # This script references the following attributes in order to accomplish this:
 # * KO_CONFIG_PATH: This is pointed to the .ko.yaml for the respective artifact


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

Support private module access at build time.

I have:

- [ ] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

locally with: GITHUB_TOKEN=$(gh auth token) VERSION=0.0.0-goprivate GO_BUILD_TAG=custom make publish
