### PR TITLE
make server port configurable and change default to avoid conflicts

### DIFF
--- a/cluster/charts/controlplane-mcp-server/templates/deploymentruntimeconfig.yaml
+++ b/cluster/charts/controlplane-mcp-server/templates/deploymentruntimeconfig.yaml
@@ -28,10 +28,14 @@ spec:
             # baseURL indicates which address and endpoint to reach out to for
             # tooling.
             - name: MCP_SERVER_TOOL_CTP1_BASEURL
-              value: http://localhost:8080/mcp
+              value: http://localhost:{{ .Values.server.port }}/mcp
           - name: controlplane-mcp-server
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (ternary .Chart.AppVersion (printf "v%s" .Chart.AppVersion) (hasPrefix "v" .Chart.AppVersion)) }}"
             args:
-            {{- with .Values.extraArgs.controlplaneMcpServer }}
-              {{- toYaml . | nindent 12 }}
+            {{- $args := .Values.extraArgs.controlplaneMcpServer | default (list) }}
+            {{- range $args }}
+            {{- printf "- %q" . | nindent 12 }}
+            {{- end }}
+            {{- if .Values.server.port }}
+            {{- printf "- --port=:%v" .Values.server.port | nindent 12 }}
             {{- end }}

--- a/cluster/charts/controlplane-mcp-server/values.yaml
+++ b/cluster/charts/controlplane-mcp-server/values.yaml
@@ -8,6 +8,10 @@ serviceAccount:
   # The name of the service account to use.
   name: function-with-ctp-mcp
 
+# This section configures the HTTP server.
+server:
+  port: 8081
+
 # ExtraArgs to specify for the given container.
 extraArgs:
   # packageRuntime is the name of the crossplane function.

--- a/cmd/controlplane-mcp-server/main.go
+++ b/cmd/controlplane-mcp-server/main.go
@@ -39,7 +39,7 @@ type Command struct {
 	Debug   bool `default:"false" env:"DEBUG"    help:"Run with debug logging."   name:"debug"    short:"d"`
 	DevMode bool `default:"false" env:"DEV_MODE" help:"Enables logging dev mode." name:"dev-mode"`
 
-	Port       string `default:":8080" help:"Address to listen on."`
+	Port       string `default:":8081" help:"Address to listen on."                                                                          short:"p"`
 	Kubeconfig string `default:""      help:"Location of the kubeconfig to use for the API clients. Default is to use the incluster config."`
 }
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

Fixes #9 

I have:

- [ ] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Ran it through official build and then installed addon + a provider referencing the runtimeconfig

```
➜  controller-manager git:(main) ✗ k logs -f -n crossplane-system upbound-provider-aws-s3-7c31556b5599-669df9c698-gbf9s -c controlplane-mcp-server
2025/08/01 18:34:31 performing bootcheck for host environment and community license validation ...
2025/08/01 18:34:31 bootchecks completed successfully. starting controllers ...
{"level":"info","ts":"2025-08-01T18:34:31Z","logger":"controlplane-mcp-server","msg":"Streamable HTTP server starting at http://localhost:8081/mcp"}
^C
➜  controller-manager git:(main) ✗ k logs -f -n crossplane-system upbound-provider-aws-s3-7c31556b5599-669df9c698-gbf9s -c package-runtime
2025/08/01 18:34:27 performing bootcheck for host environment and community license validation ...
2025/08/01 18:34:27 bootchecks completed successfully. starting provider ...
{"level":"info","ts":"2025-08-01T18:34:39Z","logger":"provider-aws","msg":"Beta feature enabled","flag":"EnableBetaManagementPolicies"}
^C
➜  controller-manager git:(main) ✗ k get pkg 
NAME                                                     INSTALLED   HEALTHY   PACKAGE                                                    AGE
provider.pkg.crossplane.io/upbound-provider-aws-s3       True        True      xpkg.dev-deba7a0e.u6d.dev/upbound/provider-aws-s3:v2       103s
provider.pkg.crossplane.io/upbound-provider-family-aws   True        True      xpkg.dev-deba7a0e.u6d.dev/upbound/provider-family-aws:v2   100s

NAME                                           INSTALLED   HEALTHY   PACKAGE                                                                               AGE
addon.pkg.upbound.io/controlplane-mcp-server   True        True      xpkg.dev-deba7a0e.u6d.dev/upbound/addon-controlplane-mcp-server:0.0.0-community.uxp   117s
```
